### PR TITLE
Add an npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,17 @@
+.vscode
+dev
+docs
+docs-src
+node_modules
+src/test
+test
+.eleventy.cjs
+.eslintrc.json
+.gitignore
+.prettierrc.json
+CONTRIBUTING.md
+custom-elements.json
+example.png
+karma.conf.cjs
+rollup.config.js
+tsconfig.json


### PR DESCRIPTION
Contents of package after this addition:

2.6kB package.json
1.2kB brick-viewer.d.ts
1.0kB brick-viewer.d.ts.map
7.5kB brick-viewer.js
5.4kB brick-viewer.js.map
1.5kB LICENSE
683B  README.md
6.7kB src/brick-viewer.ts
=>
26.6 kB unpacked